### PR TITLE
Changed the value of maven.plugin.plugin.version in pom.xml from 3.3 to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<maven-jaxb2-plugin.version>0.13.1</maven-jaxb2-plugin.version>
 		<jaxb.version>2.2.11</jaxb.version>
 		<maven.plugin.testing.version>2.1</maven.plugin.testing.version>
-		<maven.plugin.plugin.version>3.2</maven.plugin.plugin.version>
+		<maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
 		<jaxb2-basics-annotate.version>1.0.2</jaxb2-basics-annotate.version>
 		<hsqldb.version>2.3.3</hsqldb.version>
 		<hibernate-jpa-2.0-api.version>1.0.0.Final</hibernate-jpa-2.0-api.version>


### PR DESCRIPTION
3.5 (latest available)

The build failed with:
[ERROR] Failed to execute goal
org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile
(default-testCompile) on project hyperjaxb3-ejb-schemas-customizations:
Compilation failure
[ERROR]
/home/roger/hj3b/hyperjaxb3/ejb/schemas/customizations/src/test/java/org/jvnet/hyperjaxb3/ejb/schemas/customizations/tests/UnmarshalPersistenceTest.java:[56,58]
cannot access org.jvnet.hyperjaxb3.ejb.schemas.customizations.Basic
[ERROR] class file for
org.jvnet.hyperjaxb3.ejb.schemas.customizations.Basic not found

and upgrading the plugin fixes the problem.