### PR TITLE
Update to XMLGregorianCalendarAsDateTime.java

### DIFF
--- a/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
+++ b/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
@@ -23,5 +23,6 @@ public class XMLGregorianCalendarAsDateTime extends
 		calendar.setMinute(date.getMinutes());
 		calendar.setSecond(date.getSeconds());
 		calendar.setMillisecond((int) (date.getTime() % 1000));
+		calendar.setTimezone(date.getTimezoneOffset());
 	}
 }


### PR DESCRIPTION
I'm using the hyperjaxb3 Maven plugin to generate my object classes from XML Schema file (i.e., *.xsd files).  I noticed the generated object classes use this class' (XMLGregorianCalendarAsDateTime) createCalendar() method to marshal datetime information from Hibernate/JPA into my objects.  Since the createCalendar() method isignoring timezone data, my objects with datetime fields are not getting their timezones set.

This change is needed to marshal the "datetime" timezone information coming from Hibernate/JPA.